### PR TITLE
OkHttp Interceptor 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,4 +105,11 @@ dependencies {
     implementation 'com.google.firebase:firebase-analytics-ktx:21.2.0'
     implementation 'com.google.firebase:firebase-auth-ktx:21.1.0'
     implementation('org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4')
+
+    // define a BOM and its version
+    implementation(platform("com.squareup.okhttp3:okhttp-bom:4.10.0"))
+
+    // define any required OkHttp artifacts without version
+    implementation("com.squareup.okhttp3:okhttp")
+    implementation("com.squareup.okhttp3:logging-interceptor")
 }

--- a/app/src/main/java/com/example/modugarden/api/RetrofitBuilder.kt
+++ b/app/src/main/java/com/example/modugarden/api/RetrofitBuilder.kt
@@ -1,9 +1,9 @@
 package com.example.modugarden.api
 
 import com.google.gson.GsonBuilder
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import retrofit2.create
 
 object RetrofitBuilder {
     val userAPI: UserAPI
@@ -11,21 +11,29 @@ object RetrofitBuilder {
     val signupAPI: SignupAPI
     val signupEmailAuthenticationAPI: SignupEmailAuthenticationAPI
     val signupEmailIsDuplicatedAPI: SignupEmailIsDuplicatedAPI
-    val commentAPI : CommentAPI
 
     val gson = GsonBuilder().setLenient().create()
 
     init {
+        val client = OkHttpClient
+            .Builder()
+            .addInterceptor(TokenInterceptor)
+
         val retrofit = Retrofit.Builder()
+            .baseUrl("http://3.38.50.190:8080")
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .client(client.build())
+            .build()
+
+        val retrofitWithNoInterceptor = Retrofit.Builder()
             .baseUrl("http://3.38.50.190:8080")
             .addConverterFactory(GsonConverterFactory.create(gson))
             .build()
 
         userAPI = retrofit.create(UserAPI::class.java)
-        loginAPI = retrofit.create(LoginAPI::class.java)
-        signupAPI = retrofit.create(SignupAPI::class.java)
-        signupEmailAuthenticationAPI = retrofit.create(SignupEmailAuthenticationAPI::class.java)
-        signupEmailIsDuplicatedAPI = retrofit.create(SignupEmailIsDuplicatedAPI::class.java)
-        commentAPI = retrofit.create(CommentAPI::class.java)
+        loginAPI = retrofitWithNoInterceptor.create(LoginAPI::class.java)
+        signupAPI = retrofitWithNoInterceptor.create(SignupAPI::class.java)
+        signupEmailAuthenticationAPI = retrofitWithNoInterceptor.create(SignupEmailAuthenticationAPI::class.java)
+        signupEmailIsDuplicatedAPI = retrofitWithNoInterceptor.create(SignupEmailIsDuplicatedAPI::class.java)
     }
 }

--- a/app/src/main/java/com/example/modugarden/api/TokenInterceptor.kt
+++ b/app/src/main/java/com/example/modugarden/api/TokenInterceptor.kt
@@ -1,0 +1,38 @@
+package com.example.modugarden.api
+
+import android.util.Log
+import okhttp3.Interceptor
+import okhttp3.Response
+
+object TokenInterceptor: Interceptor{
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request();
+
+        val finalRequest = request.newBuilder()
+            .addHeader("authorization", "Bearer ${TokenStore.accessToken}")
+            .build()
+
+        val response = chain.proceed(finalRequest)
+
+        when (response.code) {
+            400 -> {
+                //Show Bad Request Error Message
+            }
+            401 -> {
+                // 리프레쉬로 바꿔서 다시 보냄 -> 따라서 401이 뜬 경우엔 리프레쉬도 만료된 경우
+            }
+
+            403 -> {
+                //Show Forbidden Message
+            }
+
+            404 -> {
+                //Show NotFound Message
+            }
+
+            // ... and so on
+        }
+
+        return response
+    }
+}

--- a/app/src/main/java/com/example/modugarden/api/TokenStore.kt
+++ b/app/src/main/java/com/example/modugarden/api/TokenStore.kt
@@ -1,0 +1,6 @@
+package com.example.modugarden.api
+
+object TokenStore {
+    var accessToken: String = ""
+    var refreshToken: String = ""
+}

--- a/app/src/main/java/com/example/modugarden/api/UserAPI.kt
+++ b/app/src/main/java/com/example/modugarden/api/UserAPI.kt
@@ -8,7 +8,6 @@ import retrofit2.http.Query
 interface UserAPI {
     @GET("/users")
     fun getUserByNickname(
-        @Header("Authorization") authorization: String,
         @Query("nickname") nickname: String
     ): Call<FindByNicknameRes>
 }

--- a/app/src/main/java/com/example/modugarden/api/UserDTO.kt
+++ b/app/src/main/java/com/example/modugarden/api/UserDTO.kt
@@ -1,7 +1,7 @@
 package com.example.modugarden.api
 
 data class FindByNicknameRes(
-    val content: FindByNicknameResContent,
+    val content: List<FindByNicknameResContent>,
     val first: Boolean,
     val hasNext: Boolean,
     val last: Boolean
@@ -13,19 +13,4 @@ data class FindByNicknameResContent(
     val nickname: String,
     val profileImage: String,
     val userId: Int
-)
-
-data class TestReq1(
-    val email: String
-)
-
-data class TestRes1(
-    val code: Int,
-    val isSuccess: Boolean,
-    val message: String,
-    val result: TestRes1Result
-)
-
-data class TestRes1Result(
-    val duplicate: Boolean
 )

--- a/app/src/main/java/com/example/modugarden/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/modugarden/login/LoginScreen.kt
@@ -44,6 +44,7 @@ import com.example.modugarden.api.LoginDTO
 import com.example.modugarden.api.RetrofitBuilder.loginAPI
 import com.example.modugarden.api.RetrofitBuilder.signupEmailAuthenticationAPI
 import com.example.modugarden.api.RetrofitBuilder.signupEmailIsDuplicatedAPI
+import com.example.modugarden.api.TokenStore
 import com.example.modugarden.data.SignupEmailAuthenticationDTO
 import com.example.modugarden.data.SignupEmailIsDuplicatedDTO
 import com.example.modugarden.route.NAV_ROUTE_SIGNUP
@@ -182,6 +183,8 @@ fun MainLoginScreen(navController: NavController) {
                                                         .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
                                                         .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                                                 )
+                                                TokenStore.accessToken = res.result.accessToken
+                                                TokenStore.refreshToken = res.result.refreshToken
                                             }
                                             else {
                                                 Toast.makeText(mContext, res.message, Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/example/modugarden/main/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/modugarden/main/profile/ProfileScreen.kt
@@ -375,13 +375,13 @@ fun MyProfileScreen(data:User,id:Int) {
                                         .background(color = Color.Transparent)
                                         .bounceClick {
                                             RetrofitBuilder.userAPI
-                                                .getUserByNickname(
-                                                    "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkbGRtc3RqcTk5QGdtYWlsLmNvbSIsInJvbGVzIjpbIlJPTEVfR0VORVJBTCJdLCJpYXQiOjE2NzQ4ODQ5ODYsImV4cCI6MTY3NDg4Njc4Nn0.hMxdk8INOCOp_NJiXkwj3QjytFXRW1le_wHvf1Q_4V4",
-                                                    "Mara"
-                                                )
+                                                .getUserByNickname("Mara")
                                                 .enqueue(object : Callback<FindByNicknameRes> {
                                                     override fun onResponse(call: Call<FindByNicknameRes>, response: Response<FindByNicknameRes>) {
-                                                        Log.d(ContentValues.TAG, "onResponse: \n${response.message()}")
+                                                        Log.d(ContentValues.TAG, "onResponse: " +
+                                                                "\n${response.code()}" +
+                                                                "\n${response.body()}" +
+                                                                "\n${response.message()}")
                                                     }
 
                                                     override fun onFailure(call: Call<FindByNicknameRes>, t: Throwable) {


### PR DESCRIPTION
Add : OkHttp 의존성 추가 -> 인터셉터 사용
Add : 토큰 인터셉터 인터페이스 및 토큰 저장소 추가
Modify : LoginScreen 에서 로그인 성공 시 토큰 저장소에 토큰 저장
Modify : RetrofitBuilder 에서 토큰 인터셉터가 필요하지 않은 api(ex: 회원가입, 로그인 등..)은 retrofit이 아닌 retrofitWithNoInterceptor를 통해 create 할 것