### PR TITLE
프로필 관련 api 연결

### DIFF
--- a/app/src/main/java/com/example/modugarden/ApplicationClass.kt
+++ b/app/src/main/java/com/example/modugarden/ApplicationClass.kt
@@ -23,6 +23,11 @@ class ApplicationClass : Application() {
         val accessToken = "Access Token"
         val refreshToken = "Refresh Token"
         val clientId = "Client ID"
+        val commentNotification = "Comment Notification Setting"
+        val followNotification = "Follow Notification Setting"
+        val serviceNotification = "Service Notification Setting"
+        val marketingNotification = "Marketing Notification Setting"
+        val autoLoginSetting = "Auto Login Setting"
         val refresh = "refresh"
 
         lateinit var retrofit: Retrofit

--- a/app/src/main/java/com/example/modugarden/api/AuthCallBack.kt
+++ b/app/src/main/java/com/example/modugarden/api/AuthCallBack.kt
@@ -11,7 +11,8 @@ import retrofit2.Response
 open class AuthCallBack<T>(val context: Context, val log: String) : Callback<T> {
 
     override fun onResponse(call: Call<T>, response: Response<T>) {
-        Log.d("onResponse", log)
+        Log.d("onResponse", log +
+                "\nstatus code : ${response.code()}")
         if(response.code() == 401)
         {
             context.startActivity(Intent(context, LoginActivity::class.java)
@@ -21,6 +22,8 @@ open class AuthCallBack<T>(val context: Context, val log: String) : Callback<T> 
     }
 
     override fun onFailure(call: Call<T>, t: Throwable) {
+        Log.d("onResponse",
+            "\nstatus code : ${t.localizedMessage}")
 
     }
 }

--- a/app/src/main/java/com/example/modugarden/api/TokenInterceptor.kt
+++ b/app/src/main/java/com/example/modugarden/api/TokenInterceptor.kt
@@ -1,6 +1,7 @@
 package com.example.modugarden.api
 
 import com.example.modugarden.ApplicationClass.Companion.accessToken
+import com.example.modugarden.ApplicationClass.Companion.refreshToken
 import com.example.modugarden.ApplicationClass.Companion.sharedPreferences
 import okhttp3.Interceptor
 import okhttp3.Response
@@ -9,19 +10,26 @@ object TokenInterceptor: Interceptor{
     override fun intercept(chain: Interceptor.Chain): Response {
 
         val ACCESS_TOKEN = sharedPreferences.getString(accessToken, null)
+        val REFRESH_TOKEN = sharedPreferences.getString(refreshToken, null)
 
-        val finalRequest = chain.request().newBuilder()
+        val request = chain.request()
+
+        val finalRequest = request.newBuilder()
             .addHeader("authorization", "Bearer $ACCESS_TOKEN")
             .build()
 
-        val response = chain.proceed(finalRequest)
+        var response = chain.proceed(finalRequest)
 
         when (response.code) {
             400 -> {
                 //Show Bad Request Error Message
             }
             401 -> {
-                // 리프레쉬로 바꿔서 다시 보냄 -> 따라서 401이 뜬 경우엔 리프레쉬도 만료된 경우
+                val refreshRequest = request.newBuilder()
+                    .addHeader("authorization", "Bearer $REFRESH_TOKEN")
+                    .build()
+
+                response = chain.proceed(refreshRequest)
             }
 
             403 -> {

--- a/app/src/main/java/com/example/modugarden/api/api/BlockAPI.kt
+++ b/app/src/main/java/com/example/modugarden/api/api/BlockAPI.kt
@@ -1,4 +1,25 @@
 package com.example.modugarden.api.api
 
+import com.example.modugarden.api.dto.BlockUserResponse
+import com.example.modugarden.api.dto.GetBlockedListResponse
+import com.example.modugarden.api.dto.UnBlockUserResponse
+import retrofit2.Call
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
 interface BlockAPI {
+    @GET("/blocked-list")
+    fun getBlockedList() : Call<GetBlockedListResponse>
+
+    @POST("/blocked-list/{userId}")
+    fun blockUser(
+        @Path("userId") userId: Int
+    ) : Call<BlockUserResponse>
+
+    @DELETE("/blocked-list/{userId}")
+    fun unBlockUser(
+        @Path("userId") userId: Int
+    ) : Call<UnBlockUserResponse>
 }

--- a/app/src/main/java/com/example/modugarden/api/api/CurationAPI.kt
+++ b/app/src/main/java/com/example/modugarden/api/api/CurationAPI.kt
@@ -71,7 +71,7 @@ interface CurationAPI {
 
     //프로필 페이지 - 저장한 큐레이션 조회
     @GET("/curations/me/storage")
-    fun getMyCurationStorage():Call<GetCuration>
+    fun getMyCurationStorage():Call<GetStoredCurationsResponse>
 
     // 큐레이션 보관 여부 조회
     @GET("/curations/me/storage/{curation_id}")

--- a/app/src/main/java/com/example/modugarden/api/api/PostAPI.kt
+++ b/app/src/main/java/com/example/modugarden/api/api/PostAPI.kt
@@ -76,13 +76,13 @@ interface PostAPI {
 
     //프로필 페이지- 저장한 포스트 조회
     @GET("/boards/me/storage")
-    fun getMyPostStorage() :Call<GetPost>
+    fun getMyPostStorage() :Call<GetStoredPostResponse>
 
     //게시물 상세보기 - 회원 포스트 조회
     @GET ("/boards/users/{user_id}")
     fun getUserPost(
         @Path ("user_id") user_id :Int
-    ): Call<GetPost>
+    ): Call<GetUserPostResponse>
 
     //팔로우 피드 포스트 불러오기
     @GET ("/boards/followfeed")

--- a/app/src/main/java/com/example/modugarden/api/dto/BlockDTO.kt
+++ b/app/src/main/java/com/example/modugarden/api/dto/BlockDTO.kt
@@ -1,0 +1,39 @@
+package com.example.modugarden.api.dto
+
+data class GetBlockedListResponse(
+    val content: List<GetBlockedListResponseContent>,
+    val first: Boolean,
+    val hasNext: Boolean,
+    val last: Boolean
+)
+
+data class GetBlockedListResponseContent(
+    val categories: List<String>,
+    val id: Int,
+    val nickname: String,
+    val profileImage: String
+)
+
+data class BlockUserResponse(
+    val code: Int,
+    val isSuccess: Boolean,
+    val message: String,
+    val result: List<BlockUserResponseResult>
+)
+
+data class BlockUserResponseResult(
+    val blockUserId: Int,
+    val userId: Int
+)
+
+data class UnBlockUserResponse(
+    val code: Int,
+    val isSuccess: Boolean,
+    val message: String,
+    val result: List<UnBlockUserResponseResult>
+)
+
+data class UnBlockUserResponseResult(
+    val unBlockUserId: Int,
+    val userId: Int
+)

--- a/app/src/main/java/com/example/modugarden/api/dto/CurationDTO.kt
+++ b/app/src/main/java/com/example/modugarden/api/dto/CurationDTO.kt
@@ -141,3 +141,22 @@ data class GetFollowFeedCurationContent(
     val category_category: String
 )
 
+data class GetStoredCurationsResponse(
+    val content: List<GetStoredCurationsResponseContent>,
+    val first: Boolean,
+    val hasNext: Boolean,
+    val last: Boolean
+)
+
+data class GetStoredCurationsResponseContent(
+    val category_category: String,
+    val id: Int,
+    val likeNum: Int,
+    val link: String,
+    val localDateTime: String,
+    val preview_image: String,
+    val title: String,
+    val user_id: Int,
+    val user_nickname: String,
+    val user_profile_image: String
+)

--- a/app/src/main/java/com/example/modugarden/api/dto/PostDTO.kt
+++ b/app/src/main/java/com/example/modugarden/api/dto/PostDTO.kt
@@ -126,5 +126,33 @@ class PostDTO {
         val userid:Int
     )
 
+    data class GetUserPostResponse(
+        val content: List<GetUserPostResponseContent>,
+        val first: Boolean,
+        val hasNext: Boolean,
+        val last: Boolean
+    )
 
+    data class GetUserPostResponseContent(
+        val id: Int,
+        val image: String
+    )
+
+    data class GetStoredPostResponse(
+        val content: List<GetStoredPostResponseContent>,
+        val first: Boolean,
+        val hasNext: Boolean,
+        val last: Boolean
+    )
+
+    data class GetStoredPostResponseContent(
+        val board_id: Int,
+        val category_category: String,
+        val like_num: Int,
+        val preview_img: String,
+        val title: String,
+        val user_id: Int,
+        val user_nickname: String,
+        val user_profile_image: String
+    )
 }

--- a/app/src/main/java/com/example/modugarden/main/content/CurationContentScreen.kt
+++ b/app/src/main/java/com/example/modugarden/main/content/CurationContentScreen.kt
@@ -41,7 +41,6 @@ import com.example.modugarden.api.RetrofitBuilder
 import com.example.modugarden.api.dto.GetCurationResponse
 import com.example.modugarden.main.follow.moduBold
 import com.example.modugarden.ui.theme.*
-import com.example.modugarden.viewmodel.FeedViewModel
 import kotlinx.coroutines.launch
 import retrofit2.Call
 import retrofit2.Callback
@@ -49,7 +48,7 @@ import retrofit2.Response
 
 @SuppressLint("CommitPrefEdits")
 @Composable
-fun CurationContentScreen(curation_id :Int, feedViewModel: FeedViewModel= viewModel()) {
+fun CurationContentScreen(curation_id :Int) {
     val focusManager = LocalFocusManager.current
     //액티비티 종료할 때 사용할 변수
     val activity = (LocalContext.current as? Activity)
@@ -144,9 +143,6 @@ fun CurationContentScreen(curation_id :Int, feedViewModel: FeedViewModel= viewMo
                 Icon(painter = painterResource(id = R.drawable.ic_xmark),
                     contentDescription = "창 닫기",
                     modifier = Modifier.bounceClick {
-                        editor.putInt(refresh,2)
-                        if(sharedPreferences.getInt(refresh,0)==2)
-                        editor.apply()
                         activity?.finish()
                     })
             }

--- a/app/src/main/java/com/example/modugarden/main/content/PostContentScreen.kt
+++ b/app/src/main/java/com/example/modugarden/main/content/PostContentScreen.kt
@@ -439,7 +439,7 @@ fun PostContentScreen(
                         Row(modifier = Modifier
                             .padding(25.dp, 18.dp)
                             .bounceClick {
-                                userViewModel.setUserId(1)
+                                userViewModel.setUserId(responseBody.result!!.user_id)
                                 navController.navigate(NAV_ROUTE_POSTCONTENT.WRITER.routeName)
                                 //  포스트 작성자 프로필로
 

--- a/app/src/main/java/com/example/modugarden/main/follow/PostCard.kt
+++ b/app/src/main/java/com/example/modugarden/main/follow/PostCard.kt
@@ -94,7 +94,7 @@ fun PostCard(
                                         modifier = Modifier
                                                 .padding(18.dp)
                                                 .bounceClick {
-                                                        userViewModel.setUserId(1)
+                                                        userViewModel.setUserId(data.user_id)
                                                         navController.navigate(NAV_ROUTE_FOLLOW.USERPROFILE.routeName) {
                                                         }
                                                 },//프로필

--- a/app/src/main/java/com/example/modugarden/main/profile/ProfileSaveActivity.kt
+++ b/app/src/main/java/com/example/modugarden/main/profile/ProfileSaveActivity.kt
@@ -5,18 +5,31 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import com.example.modugarden.R
+import com.example.modugarden.api.AuthCallBack
+import com.example.modugarden.api.RetrofitBuilder
+import com.example.modugarden.api.dto.GetStoredCurationsResponse
+import com.example.modugarden.api.dto.GetStoredCurationsResponseContent
+import com.example.modugarden.api.dto.PostDTO
 import com.example.modugarden.ui.theme.TopBar
+import retrofit2.Call
+import retrofit2.Response
 
 class ProfileSaveActivity: ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             // 인텐트로 포스트, 큐레이션 리스트 받아옴
-            Column (
-                modifier = Modifier.fillMaxSize()
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
             ) {
                 TopBar(
                     title = "저장한 항목",
@@ -26,7 +39,54 @@ class ProfileSaveActivity: ComponentActivity() {
                     },
                     bottomLine = false
                 )
-                CuratorProfileTab()
+
+                val postList = remember {
+                    mutableStateOf(
+                        listOf(
+                            PostDTO.GetStoredPostResponseContent(
+                                0, "", 0, "", "", 0, "", ""
+                            )
+                        )
+                    )
+                }
+
+                val curationList = remember {
+                    mutableStateOf(
+                        listOf(
+                            GetStoredCurationsResponseContent(
+                                "", 0, 0, "", "", "", "", 0, "", ""
+                            )
+                        )
+                    )
+                }
+
+                RetrofitBuilder.postAPI.getMyPostStorage()
+                    .enqueue(object :
+                        AuthCallBack<PostDTO.GetStoredPostResponse>(this@ProfileSaveActivity, "저장된 항목 부르기 성공!") {
+                        override fun onResponse(
+                            call: Call<PostDTO.GetStoredPostResponse>,
+                            response: Response<PostDTO.GetStoredPostResponse>
+                        ) {
+                            super.onResponse(call, response)
+                            if (response.body()?.content != null)
+                                postList.value = response.body()?.content!!
+                        }
+                    })
+
+                RetrofitBuilder.curationAPI.getMyCurationStorage()
+                    .enqueue(object :
+                        AuthCallBack<GetStoredCurationsResponse>(this@ProfileSaveActivity, "저장된 항목 부르기 성공!") {
+                        override fun onResponse(
+                            call: Call<GetStoredCurationsResponse>,
+                            response: Response<GetStoredCurationsResponse>
+                        ) {
+                            super.onResponse(call, response)
+                            if (response.body()?.content != null)
+                                curationList.value = response.body()?.content!!
+                        }
+                    })
+
+                StoredTab(postList.value, curationList.value)
             }
         }
     }

--- a/app/src/main/java/com/example/modugarden/main/profile/ProfileTabScreen.kt
+++ b/app/src/main/java/com/example/modugarden/main/profile/ProfileTabScreen.kt
@@ -1,5 +1,6 @@
 package com.example.modugarden.main.profile
 
+import android.content.Context
 import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
@@ -16,7 +17,10 @@ import androidx.compose.material.TabRow
 import androidx.compose.material.TabRowDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -26,6 +30,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.StrokeCap.Companion.Square
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -33,7 +38,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
+import com.example.modugarden.ApplicationClass.Companion.clientId
+import com.example.modugarden.ApplicationClass.Companion.sharedPreferences
 import com.example.modugarden.R
+import com.example.modugarden.api.AuthCallBack
+import com.example.modugarden.api.RetrofitBuilder
+import com.example.modugarden.api.dto.*
+import com.example.modugarden.api.dto.PostDTO.*
 import com.example.modugarden.data.CurationCard
 import com.example.modugarden.data.PostCard
 import com.example.modugarden.data.User
@@ -42,12 +53,14 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.pagerTabIndicatorOffset
 import com.google.accompanist.pager.rememberPagerState
+import com.skydoves.landscapist.glide.GlideImage
 import kotlinx.coroutines.launch
+import retrofit2.Call
+import retrofit2.Response
 
 @Composable
 fun ProfileTab (
-    // 포스트 리스트
-    postList: List<PostCard> = user.post!!
+    postList: List<GetUserPostResponseContent>
 ) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(3),
@@ -70,17 +83,23 @@ fun ProfileTab (
             Box(modifier = Modifier.bounceClick {
 
             }) {
-                Image(
-                    painter = painterResource(id = postCard.image),
+                GlideImage(
+                    imageModel =
+                    if(postCard.id == 0) {
+                        R.drawable.plus
+                    }
+                    else {
+                        postCard.image
+                    },
                     contentDescription = null,
                     modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(1f)
-                        .clip(RoundedCornerShape(15.dp))
-                        .background(moduBackground),
+                        Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(1f)
+                            .clip(RoundedCornerShape(15.dp))
+                            .background(moduBackground),
                     contentScale =
-                    if(postCard.category == "Upload") {
+                    if(postCard.id == 0) {
                         ContentScale.None
                     }
                     else {
@@ -93,12 +112,10 @@ fun ProfileTab (
 }
 
 @OptIn(ExperimentalPagerApi::class)
-@Preview(showBackground = true)
 @Composable
 fun CuratorProfileTab(
-    // 포스트 및 큐레이션 리스트
-    postList: List<PostCard> = user.post!!,
-    curationList: List<CurationCard> = user.curation!!
+    postList: List<GetUserPostResponseContent>,
+    curationList: List<GetCurationContent>
 ) {
     val pagerState = rememberPagerState()
     val coroutineScope = rememberCoroutineScope()
@@ -155,17 +172,22 @@ fun CuratorProfileTab(
                         Box(modifier = Modifier.bounceClick {
 
                         }) {
-                            Image(
-                                painter = painterResource(id = postCard.image),
+                            GlideImage(
+                                imageModel =
+                                if(postCard.id == 0) {
+                                    R.drawable.plus
+                                }
+                                else {
+                                    postCard.image
+                                },
                                 contentDescription = null,
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .aspectRatio(1f)
-                                        .clip(RoundedCornerShape(15.dp))
-                                        .background(moduBackground),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .aspectRatio(1f)
+                                    .clip(RoundedCornerShape(15.dp))
+                                    .background(moduBackground),
                                 contentScale =
-                                if(postCard.category == "Upload") {
+                                if(postCard.id == 0) {
                                     ContentScale.None
                                 }
                                 else {
@@ -190,16 +212,20 @@ fun CuratorProfileTab(
 
                                 }
                         ) {
-                            Image(
-                                painter = painterResource(id = curationCard.thumbnail_image),
+                            GlideImage(
+                                imageModel = if(curationCard.id == 0) {
+                                    curationCard.user_id
+                                }
+                                else {
+                                    curationCard.preview_image
+                                },
                                 contentDescription = null,
-                                modifier =
-                                Modifier
+                                modifier = Modifier
                                     .size(90.dp)
                                     .clip(RoundedCornerShape(15.dp))
                                     .background(moduBackground),
                                 contentScale =
-                                if(curationCard.category == "Upload") {
+                                if(curationCard.id == 0) {
                                     ContentScale.None
                                 }
                                 else {
@@ -207,7 +233,7 @@ fun CuratorProfileTab(
                                 }
                             )
                             Spacer(modifier = Modifier.width(18.dp))
-                            if(curationCard.category == "Upload") {
+                            if(curationCard.id == 0) {
                                 Text(
                                     text = curationCard.title,
                                     style = TextStyle(
@@ -234,7 +260,170 @@ fun CuratorProfileTab(
                                     )
                                     Spacer(modifier = Modifier.weight(1f))
                                     Text(
-                                        text = "${curationCard.category}, ${curationCard.time}",
+                                        text = "${curationCard.category_category}, ${curationCard.created_date}",
+                                        fontSize = 12.sp,
+                                        color = moduGray_strong
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalPagerApi::class)
+@Composable
+fun StoredTab(
+    postList: List<GetStoredPostResponseContent>,
+    curationList: List<GetStoredCurationsResponseContent>
+) {
+    val pagerState = rememberPagerState()
+    val coroutineScope = rememberCoroutineScope()
+
+    TabRow(
+        selectedTabIndex = pagerState.currentPage,
+        backgroundColor = Color.White,
+        contentColor = moduBlack,
+        indicator = { tabPositions ->
+            TabRowDefaults.Indicator(
+                Modifier.pagerTabIndicatorOffset(pagerState,tabPositions),
+                color = moduBlack
+            )
+        }
+    ) {
+        pages.forEachIndexed { index, title ->
+            Tab(
+                text = {
+                    Text(
+                        text = title,
+                        fontSize = 16.sp,
+                        color =
+                        if(pagerState.currentPage == index) moduBlack
+                        else moduGray_strong
+                    )
+                },
+                selected = pagerState.currentPage == index,
+                onClick = {
+                    coroutineScope.launch {
+                        pagerState.animateScrollToPage(index)
+                    }
+                }
+            )
+        }
+    }
+
+    HorizontalPager(
+        count = pages.size,
+        state = pagerState,
+        modifier = Modifier
+            .fillMaxSize()
+    ) { page ->
+        when(page) {
+            0 -> {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(3),
+                    verticalArrangement = Arrangement.spacedBy(18.dp),
+                    horizontalArrangement = Arrangement.spacedBy(18.dp),
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(18.dp)
+                ) {
+                    items(postList) { postCard ->
+                        // 이미지가 들어간 버튼을 넣어야 함
+                        Box(modifier = Modifier.bounceClick {
+
+                        }) {
+                            GlideImage(
+                                imageModel =
+                                if(postCard.board_id == 0) {
+                                    R.drawable.plus
+                                }
+                                else {
+                                    postCard.preview_img
+                                },
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .aspectRatio(1f)
+                                    .clip(RoundedCornerShape(15.dp))
+                                    .background(moduBackground),
+                                contentScale =
+                                if(postCard.board_id == 0) {
+                                    ContentScale.None
+                                }
+                                else {
+                                    ContentScale.Crop
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+            1 -> {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(15.dp),
+                    contentPadding = PaddingValues(18.dp)
+                ) {
+                    items(curationList) { curationCard ->
+                        Row(
+                            modifier = Modifier
+                                .height(90.dp)
+                                .bounceClick {
+
+                                }
+                        ) {
+                            GlideImage(
+                                imageModel = if(curationCard.id == 0) {
+                                    curationCard.user_id
+                                }
+                                else {
+                                    curationCard.preview_image
+                                },
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(90.dp)
+                                    .clip(RoundedCornerShape(15.dp))
+                                    .background(moduBackground),
+                                contentScale =
+                                if(curationCard.id == 0) {
+                                    ContentScale.None
+                                }
+                                else {
+                                    ContentScale.Crop
+                                }
+                            )
+                            Spacer(modifier = Modifier.width(18.dp))
+                            if(curationCard.id == 0) {
+                                Text(
+                                    text = curationCard.title,
+                                    style = TextStyle(
+                                        color = moduGray_strong,
+                                        fontSize = 14.sp,
+                                        fontWeight = FontWeight.Bold
+                                    ),
+                                    modifier = Modifier.align(Alignment.CenterVertically)
+                                )
+                            }
+                            else {
+                                Column(
+                                    modifier = Modifier
+                                        .height(42.dp)
+                                        .align(Alignment.CenterVertically)
+                                ) {
+                                    Text(
+                                        text = curationCard.title,
+                                        style = TextStyle(
+                                            color = Color.Black,
+                                            fontWeight = FontWeight.Bold,
+                                            fontSize = 14.sp
+                                        )
+                                    )
+                                    Spacer(modifier = Modifier.weight(1f))
+                                    Text(
+                                        text = "${curationCard.category_category}, ${curationCard.localDateTime.split('T')[0]}",
                                         fontSize = 12.sp,
                                         color = moduGray_strong
                                     )

--- a/app/src/main/java/com/example/modugarden/main/profile/follow/ProfileFollowActivity.kt
+++ b/app/src/main/java/com/example/modugarden/main/profile/follow/ProfileFollowActivity.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.*
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,170 +40,14 @@ import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 
-val pages = listOf("팔로워", "팔로잉")
 
-@OptIn(ExperimentalPagerApi::class)
+
 class ProfileFollowActivity : ComponentActivity() {
-
-    var newFollowerList = mutableListOf<FollowListDtoResContent>()
-    var newFollowingList = mutableListOf<FollowListDtoResContent>()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            // A surface container using the 'background' color from the theme
-            val scope = rememberCoroutineScope()
-            val scaffoldState = rememberScaffoldState()
-            val id = intent.extras?.getInt("userId")
-            Log.d("userId", id.toString())
-
-            if (id != null) {
-                RetrofitBuilder.followAPI.otherFollowerList(id)
-                    .enqueue(object : Callback<FollowListDtoRes> {
-                        override fun onResponse(
-                            call: Call<FollowListDtoRes>,
-                            response: Response<FollowListDtoRes>
-                        ) {
-                            Log.d("onResponse", response.code().toString() +
-                                    "\n" + (response.body()?.content))
-                            response.body()?.let { newFollowerList.addAll(it.content) }
-                        }
-
-                        override fun onFailure(call: Call<FollowListDtoRes>, t: Throwable) {
-                            Log.d("onFailure", "안됨")
-                        }
-                    })
-                RetrofitBuilder.followAPI.otherFollowingList(id)
-                    .enqueue(object : AuthCallBack<FollowListDtoRes>(this, "성공") {
-                        override fun onResponse(
-                            call: Call<FollowListDtoRes>,
-                            response: Response<FollowListDtoRes>
-                        ) {
-                            super.onResponse(call, response)
-                            Log.d("onResponse", response.code().toString() +
-                                     "\n" + (response.body()?.content)
-                            )
-                            response.body()?.let { newFollowingList.addAll(it.content) }
-                        }
-
-                        override fun onFailure(call: Call<FollowListDtoRes>, t: Throwable) {
-                            Log.d("onFailure", "안됨")
-                        }
-                    })
-            }
-            Scaffold(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(color = Color.White),
-                scaffoldState = scaffoldState,
-                snackbarHost = {
-                    ScaffoldSnackBar (
-                        snackbarHostState = it
-                    )
-                }
-            ) {
-                val pagerState = rememberPagerState()
-                val coroutineScope = rememberCoroutineScope()
-                Column(
-                    modifier = Modifier
-                        .padding(it)
-                        .fillMaxSize()
-                        .background(Color.White)
-                ) {
-                    TopBar(
-                        title = "팔로우",
-                        titleIcon = R.drawable.ic_arrow_left_bold,
-                        titleIconOnClick = { finish() },
-                        bottomLine = false
-                    )
-                    TabRow(
-                        selectedTabIndex = pagerState.currentPage,
-                        backgroundColor = Color.White,
-                        contentColor = moduBlack,
-                        indicator = { tabPositions ->
-                            TabRowDefaults.Indicator(
-                                Modifier.pagerTabIndicatorOffset(pagerState, tabPositions),
-                                color = Color.Black
-                            )
-                        }
-                    ) {
-                        pages.forEachIndexed { index, title ->
-                            Tab(
-                                text = {
-                                    Text(
-                                        text = title,
-                                        fontSize = 16.sp,
-                                        color =
-                                        if(pagerState.currentPage == index) moduBlack
-                                        else moduGray_strong
-                                    )
-                                },
-                                selected = pagerState.currentPage == index,
-                                onClick = {
-                                    coroutineScope.launch {
-                                        pagerState.animateScrollToPage(index)
-                                    }
-                                }
-                            )
-                        }
-                    }
-
-                    HorizontalPager(
-                        count = pages.size,
-                        state = pagerState,
-                        modifier = Modifier
-                            .fillMaxSize()
-                    ) { page ->
-                        when (page) {
-                            0 -> {
-                                LazyColumn(
-                                    modifier = Modifier
-                                        .padding(18.dp)
-                                        .fillMaxSize(),
-                                    verticalArrangement = Arrangement.spacedBy(18.dp)
-                                ) {
-                                    items(newFollowerList) { follower ->
-                                        ProfileCard(follower) { isFollowing ->
-                                            scope.launch {
-                                                if (isFollowing)
-                                                    scaffoldState.snackbarHostState.showSnackbar(
-                                                        "${follower.nickname} 님을 언팔로우 했어요."
-                                                    )
-                                                else
-                                                    scaffoldState.snackbarHostState.showSnackbar(
-                                                        "${follower.nickname} 님을 팔로우 했어요."
-                                                    )
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            1 -> {
-                                LazyColumn(
-                                    modifier = Modifier
-                                        .padding(18.dp)
-                                        .fillMaxSize(),
-                                    verticalArrangement = Arrangement.spacedBy(18.dp)
-                                ) {
-                                    items(newFollowingList) { following ->
-                                        ProfileCard(following) { isFollowing ->
-                                            scope.launch {
-                                                if (isFollowing)
-                                                    scaffoldState.snackbarHostState.showSnackbar(
-                                                        "${following.nickname} 님을 언팔로우 했어요."
-                                                    )
-                                                else
-                                                    scaffoldState.snackbarHostState.showSnackbar(
-                                                        "${following.nickname} 님을 팔로우 했어요."
-                                                    )
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            val userId = intent.getIntExtra("userId", 0)
+            ProfileFollow(userId, this@ProfileFollowActivity)
         }
     }
 }

--- a/app/src/main/java/com/example/modugarden/main/profile/follow/ProfileFollowCard.kt
+++ b/app/src/main/java/com/example/modugarden/main/profile/follow/ProfileFollowCard.kt
@@ -1,12 +1,7 @@
 package com.example.modugarden.main.profile.follow
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Card
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ScaffoldState
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -14,36 +9,33 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.modugarden.R
-import com.example.modugarden.api.dto.FollowListDtoRes
+import androidx.navigation.NavController
 import com.example.modugarden.api.dto.FollowListDtoResContent
-import com.example.modugarden.data.User
+import com.example.modugarden.main.profile.ProfileScreen
 
 import com.example.modugarden.ui.theme.*
-import com.google.android.gms.common.api.Scope
+import com.example.modugarden.viewmodel.UserViewModel
 import com.skydoves.landscapist.glide.GlideImage
-import kotlinx.coroutines.launch
 
 // 팔로잉, 팔로워 프로필 카드
 @Composable
 fun ProfileCard(
     user: FollowListDtoResContent,
+    navController: NavController,
+    viewModel: UserViewModel,
     onClick: (Boolean) -> Unit = {}
 ) {
     Row(
         modifier = Modifier
             .height(50.dp)
             .bounceClick {
-
+                viewModel.setUserId(user.userId)
+                navController.navigate(ProfileFollowScreen.Profile.name)
             }
     ) {
         GlideImage(

--- a/app/src/main/java/com/example/modugarden/main/profile/follow/ProfileFollowMainScreen.kt
+++ b/app/src/main/java/com/example/modugarden/main/profile/follow/ProfileFollowMainScreen.kt
@@ -1,0 +1,206 @@
+package com.example.modugarden.main.profile.follow
+
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.example.modugarden.R
+import com.example.modugarden.api.AuthCallBack
+import com.example.modugarden.api.RetrofitBuilder
+import com.example.modugarden.api.dto.FollowListDtoRes
+import com.example.modugarden.api.dto.FollowListDtoResContent
+import com.example.modugarden.ui.theme.ScaffoldSnackBar
+import com.example.modugarden.ui.theme.TopBar
+import com.example.modugarden.ui.theme.moduBlack
+import com.example.modugarden.ui.theme.moduGray_strong
+import com.example.modugarden.viewmodel.UserViewModel
+import com.google.accompanist.pager.ExperimentalPagerApi
+import com.google.accompanist.pager.HorizontalPager
+import com.google.accompanist.pager.pagerTabIndicatorOffset
+import com.google.accompanist.pager.rememberPagerState
+import kotlinx.coroutines.launch
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+val pages = listOf("팔로워", "팔로잉")
+
+@OptIn(ExperimentalPagerApi::class)
+@Composable
+fun ProfileFollowMainScreen(
+    id: Int,
+    navController: NavController,
+    viewModel: UserViewModel,
+    onBackClick: () -> Unit
+) {
+    val scope = rememberCoroutineScope()
+    val scaffoldState = rememberScaffoldState()
+    Log.d("userId", id.toString())
+    val newFollowerList = remember { mutableStateListOf<FollowListDtoResContent>() }
+    val newFollowingList = remember { mutableStateListOf<FollowListDtoResContent>() }
+    val context = LocalContext.current
+
+    RetrofitBuilder.followAPI.otherFollowerList(id)
+        .enqueue(object : Callback<FollowListDtoRes> {
+            override fun onResponse(
+                call: Call<FollowListDtoRes>,
+                response: Response<FollowListDtoRes>
+            ) {
+                Log.d("onResponse", response.code().toString() +
+                        "\n" + (response.body()?.content))
+                response.body()?.let { newFollowerList.addAll(it.content) }
+            }
+
+            override fun onFailure(call: Call<FollowListDtoRes>, t: Throwable) {
+                Log.d("onFailure", "안됨")
+            }
+        })
+    RetrofitBuilder.followAPI.otherFollowingList(id)
+        .enqueue(object : AuthCallBack<FollowListDtoRes>(context, "성공") {
+            override fun onResponse(
+                call: Call<FollowListDtoRes>,
+                response: Response<FollowListDtoRes>
+            ) {
+                super.onResponse(call, response)
+                Log.d(
+                    "onResponse", response.code().toString() +
+                            "\n" + (response.body()?.content)
+                )
+                response.body()?.let { newFollowingList.addAll(it.content) }
+            }
+
+            override fun onFailure(call: Call<FollowListDtoRes>, t: Throwable) {
+                Log.d("onFailure", "안됨")
+            }
+        })
+
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Color.White),
+        scaffoldState = scaffoldState,
+        snackbarHost = {
+            ScaffoldSnackBar (
+                snackbarHostState = it
+            )
+        }
+    ) {
+        val pagerState = rememberPagerState()
+        val coroutineScope = rememberCoroutineScope()
+        Column(
+            modifier = Modifier
+                .padding(it)
+                .fillMaxSize()
+                .background(Color.White)
+        ) {
+            TopBar(
+                title = "팔로우",
+                titleIcon = R.drawable.ic_arrow_left_bold,
+                titleIconOnClick = { onBackClick() },
+                bottomLine = false
+            )
+            TabRow(
+                selectedTabIndex = pagerState.currentPage,
+                backgroundColor = Color.White,
+                contentColor = moduBlack,
+                indicator = { tabPositions ->
+                    TabRowDefaults.Indicator(
+                        Modifier.pagerTabIndicatorOffset(pagerState, tabPositions),
+                        color = Color.Black
+                    )
+                }
+            ) {
+                pages.forEachIndexed { index, title ->
+                    Tab(
+                        text = {
+                            Text(
+                                text = title,
+                                fontSize = 16.sp,
+                                color =
+                                if(pagerState.currentPage == index) moduBlack
+                                else moduGray_strong
+                            )
+                        },
+                        selected = pagerState.currentPage == index,
+                        onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(index)
+                            }
+                        }
+                    )
+                }
+            }
+
+            HorizontalPager(
+                count = pages.size,
+                state = pagerState,
+                modifier = Modifier
+                    .fillMaxSize()
+            ) { page ->
+                when (page) {
+                    0 -> {
+                        LazyColumn(
+                            modifier = Modifier
+                                .padding(18.dp)
+                                .fillMaxSize(),
+                            verticalArrangement = Arrangement.spacedBy(18.dp)
+                        ) {
+                            items(newFollowerList) { follower ->
+                                ProfileCard(follower, navController, viewModel) { isFollowing ->
+                                    scope.launch {
+                                        if (isFollowing)
+                                            scaffoldState.snackbarHostState.showSnackbar(
+                                                "${follower.nickname} 님을 언팔로우 했어요."
+                                            )
+                                        else
+                                            scaffoldState.snackbarHostState.showSnackbar(
+                                                "${follower.nickname} 님을 팔로우 했어요."
+                                            )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    1 -> {
+                        LazyColumn(
+                            modifier = Modifier
+                                .padding(18.dp)
+                                .fillMaxSize(),
+                            verticalArrangement = Arrangement.spacedBy(18.dp)
+                        ) {
+                            items(newFollowingList) { following ->
+                                ProfileCard(following, navController, viewModel) { isFollowing ->
+                                    scope.launch {
+                                        if (isFollowing)
+                                            scaffoldState.snackbarHostState.showSnackbar(
+                                                "${following.nickname} 님을 언팔로우 했어요."
+                                            )
+                                        else
+                                            scaffoldState.snackbarHostState.showSnackbar(
+                                                "${following.nickname} 님을 팔로우 했어요."
+                                            )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/modugarden/main/profile/follow/ProfileFollowScreen.kt
+++ b/app/src/main/java/com/example/modugarden/main/profile/follow/ProfileFollowScreen.kt
@@ -1,0 +1,37 @@
+package com.example.modugarden.main.profile.follow
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.modugarden.main.profile.ProfileScreen
+import com.example.modugarden.viewmodel.UserViewModel
+
+enum class ProfileFollowScreen (val title: String) {
+    Main(title = "팔로우"),
+    Profile(title = "프로필")
+}
+
+@Composable
+fun ProfileFollow (
+    userId: Int,
+    activity: ProfileFollowActivity,
+    viewModel: UserViewModel = viewModel(),
+    navController: NavHostController = rememberNavController()
+) {
+    NavHost(
+        navController = navController,
+        startDestination = ProfileFollowScreen.Main.name,
+    ) {
+        composable(route = ProfileFollowScreen.Main.name) {
+            ProfileFollowMainScreen(userId, navController, viewModel) {
+                activity.finish()
+            }
+        }
+        composable(route = ProfileFollowScreen.Profile.name) {
+            ProfileScreen(viewModel.getUserId())
+        }
+    }
+}

--- a/app/src/main/java/com/example/modugarden/main/settings/SettingsNotificationScreen.kt
+++ b/app/src/main/java/com/example/modugarden/main/settings/SettingsNotificationScreen.kt
@@ -26,6 +26,12 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.modugarden.ApplicationClass.Companion.autoLoginSetting
+import com.example.modugarden.ApplicationClass.Companion.commentNotification
+import com.example.modugarden.ApplicationClass.Companion.followNotification
+import com.example.modugarden.ApplicationClass.Companion.marketingNotification
+import com.example.modugarden.ApplicationClass.Companion.serviceNotification
+import com.example.modugarden.ApplicationClass.Companion.sharedPreferences
 import com.example.modugarden.R
 import com.example.modugarden.ui.theme.*
 
@@ -37,26 +43,32 @@ fun SettingsNotificationScreen () {
             .fillMaxSize()
             .background(moduBackground)
     ) {
-        val commentState = remember { mutableStateOf(true) }
-        val followState = remember { mutableStateOf(true) }
-        val serviceState = remember { mutableStateOf(true) }
-        val marketingState = remember { mutableStateOf(true) }
-        val autoLoginState = remember { mutableStateOf(false) }
-        Notifications(checkState = commentState, option = "댓글 알림")
-        Notifications(checkState = followState, option = "팔로우 알림")
+        val commentState = remember {
+            mutableStateOf(sharedPreferences.getBoolean(commentNotification, true)) }
+        val followState = remember {
+            mutableStateOf(sharedPreferences.getBoolean(followNotification, true)) }
+        val serviceState = remember {
+            mutableStateOf(sharedPreferences.getBoolean(serviceNotification,true)) }
+        val marketingState = remember {
+            mutableStateOf(sharedPreferences.getBoolean(marketingNotification, true)) }
+        val autoLoginState = remember {
+            mutableStateOf(sharedPreferences.getBoolean(autoLoginSetting, false)) }
+        Notifications(checkState = commentState, option = "댓글 알림", commentNotification)
+        Notifications(checkState = followState, option = "팔로우 알림", followNotification)
         Spacer(modifier = Modifier.height(18.dp))
-        Notifications(checkState = serviceState, option = "서비스 알림")
+        Notifications(checkState = serviceState, option = "서비스 알림", serviceNotification)
         Spacer(modifier = Modifier.height(18.dp))
-        Notifications(checkState = marketingState, option = "마케팅 알림")
+        Notifications(checkState = marketingState, option = "마케팅 알림", marketingNotification)
         Spacer(modifier = Modifier.height(18.dp))
-        Notifications(checkState = autoLoginState, option = "자동 로그인")
+        Notifications(checkState = autoLoginState, option = "자동 로그인", autoLoginSetting)
     }
 }
 
 @Composable
 fun Notifications (
     checkState: MutableState<Boolean>,
-    option: String
+    option: String,
+    settingKey: String
 ) {
     Row(
         modifier = Modifier
@@ -97,6 +109,7 @@ fun Notifications (
                         onTap = {
                             // This is called when the user taps on the canvas
                             checkState.value = !checkState.value
+                            sharedPreferences.edit().putBoolean(settingKey, checkState.value).apply()
                         }
                     )
                 }

--- a/app/src/main/java/com/example/modugarden/route/DiscoverSearchNavRoute.kt
+++ b/app/src/main/java/com/example/modugarden/route/DiscoverSearchNavRoute.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -12,7 +11,7 @@ import androidx.navigation.compose.composable
 import com.example.modugarden.main.discover.search.DiscoverSearchResultScreen
 import com.example.modugarden.main.discover.search.DiscoverSearchScreen
 import com.example.modugarden.main.discover.search.DiscoverSearchingScreen
-import com.example.modugarden.main.profile.MyProfileScreen
+import com.example.modugarden.main.profile.ProfileScreen
 import com.example.modugarden.viewmodel.UserViewModel
 
 enum class NAV_ROUTE_DISCOVER_SEARCH(val routeName: String, val description: String) { //upload 패키지 루트.
@@ -51,7 +50,7 @@ fun NavigationGraphDiscoverSearch(
         composable(
             NAV_ROUTE_DISCOVER_SEARCH.DISCOVERSEARCHUSERPROFILE.routeName
         ) {
-            MyProfileScreen(userId = userViewModel.getUserId())
+            ProfileScreen(userId = userViewModel.getUserId())
         }
     }
 }

--- a/app/src/main/java/com/example/modugarden/route/FollowRoute.kt
+++ b/app/src/main/java/com/example/modugarden/route/FollowRoute.kt
@@ -7,13 +7,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.example.modugarden.data.followPosts
 import com.example.modugarden.main.follow.FollowMainScreen
-import com.example.modugarden.main.profile.MyProfileScreen
+import com.example.modugarden.main.profile.ProfileScreen
 import com.example.modugarden.viewmodel.UserViewModel
 
 enum class NAV_ROUTE_FOLLOW(val routeName: String, val description: String){
@@ -40,7 +39,7 @@ fun NavigationGraphFollow(
         composable(
             NAV_ROUTE_FOLLOW.USERPROFILE.routeName
         ) { backStackEntry ->
-            MyProfileScreen(1)
+            ProfileScreen(userViewModel.getUserId())
         }
     }
 }

--- a/app/src/main/java/com/example/modugarden/route/NavRoute.kt
+++ b/app/src/main/java/com/example/modugarden/route/NavRoute.kt
@@ -12,21 +12,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
-import androidx.navigation.NavType
-import androidx.navigation.navArgument
-import com.example.modugarden.ApplicationClass
 import com.example.modugarden.ApplicationClass.Companion.clientId
 import com.example.modugarden.ApplicationClass.Companion.sharedPreferences
 import com.google.accompanist.navigation.animation.composable
 import com.example.modugarden.R
-import com.example.modugarden.data.followPosts
 import com.example.modugarden.main.discover.DiscoverScreen
-import com.example.modugarden.main.follow.FollowMainScreen
 import com.example.modugarden.main.follow.FollowScreen
 import com.example.modugarden.main.notification.NotificationScreen
-import com.example.modugarden.main.profile.MyProfileScreen
+import com.example.modugarden.main.profile.ProfileScreen
 import com.example.modugarden.main.upload.UploadScreen
-import com.example.modugarden.viewmodel.CommentViewModel
 import com.example.modugarden.viewmodel.UserViewModel
 import com.google.accompanist.navigation.animation.AnimatedNavHost
 
@@ -54,7 +48,7 @@ fun NavigationGraphBNB(
     AnimatedNavHost(navController, startDestination = NAV_ROUTE_BNB.FOLLOW.routeName,
         modifier = Modifier.fillMaxSize()) {
         composable(NAV_ROUTE_FOLLOW.USERPROFILE.routeName){
-            MyProfileScreen(userViewModel.getUserId())
+            ProfileScreen(userViewModel.getUserId())
         }
         composable(
             NAV_ROUTE_BNB.FOLLOW.routeName,
@@ -167,7 +161,7 @@ fun NavigationGraphBNB(
                 fadeOut(animationSpec = tween(fadeOutDuration)) +
                         slideOutOfContainer(AnimatedContentScope.SlideDirection.Right, animationSpec = tween(slideOutDuration))
             }
-        ) { MyProfileScreen(sharedPreferences.getInt(clientId, 0)) }
+        ) { ProfileScreen(sharedPreferences.getInt(clientId, 0)) }
     }
 }
 

--- a/app/src/main/java/com/example/modugarden/route/PostContentNavRoute.kt
+++ b/app/src/main/java/com/example/modugarden/route/PostContentNavRoute.kt
@@ -14,7 +14,7 @@ import com.example.modugarden.main.content.PostContentCommentScreen
 import com.example.modugarden.main.content.PostContentLocationScreen
 import com.example.modugarden.main.content.PostContentMapScreen
 import com.example.modugarden.main.content.PostContentScreen
-import com.example.modugarden.main.profile.MyProfileScreen
+import com.example.modugarden.main.profile.ProfileScreen
 import com.example.modugarden.viewmodel.CommentViewModel
 import com.example.modugarden.viewmodel.UserViewModel
 
@@ -49,7 +49,7 @@ fun NavigationGraphPostContent(navController: NavHostController,
             )
         }
 
-        composable(NAV_ROUTE_POSTCONTENT.WRITER.routeName) { MyProfileScreen(userViewModel.getUserId()) }
+        composable(NAV_ROUTE_POSTCONTENT.WRITER.routeName) { ProfileScreen(userViewModel.getUserId()) }
 
         composable(NAV_ROUTE_POSTCONTENT.LOCATION.routeName) {}
         composable(NAV_ROUTE_POSTCONTENT.MAP.routeName)


### PR DESCRIPTION
Add : Block 관련 api, dto
Add : 팔로우 목록 NavHost
Modify : 큐레이션, 포스트에 있는 프로필과 프로필 화면 연결
Modify : 프로필에 포스트 큐레이션 연결
Modify : 저장한 항목 API 연결
Modify : 푸시 알림 설정 sp에 저장
Modify : 토큰 인터셉터에 리프레쉬 토큰 담는 기능 추가
Modify : AuthCallBack 은 이제 코드를 같이 띄워줌
Modify : PostAPI 및 CurationAPI 에 수정된 데이터 클래스 설정 및 DTO 추가
Modify : 팔로워 목록의 프로필과 프로필 화면 연결